### PR TITLE
ipfs friends event update

### DIFF
--- a/content/events/ipfsFriendsCafeParis.md
+++ b/content/events/ipfsFriendsCafeParis.md
@@ -1,14 +1,12 @@
 ---
 eventName: "IPFS + Friends Cafe: Paris" 
-eventDescription: "​Cafes emerged in Europe in the 17th century, serving as a place to foster community and promote the exchange of ideas and philosophy. Paris also welcomed in this Age of Englightenment.
-​Fitting for us, we'd like to invite you to join us in Paris during EthCC at the IPFS & Friends Cafe to discuss or present anything IPFS or Dweb related.
-Our venue is not yet confirmed but we are looking at July 17." 
+eventDescription: "Cafes emerged in Europe in the 17th century as a place to foster community and promote the exchange of ideas and philosophy. We’d like to invite you to join us in Paris during EthCC at the IPFS & Friends Cafe!" 
 location: "Paris, France" 
 website: "http://lu.ma/ipfsnfriends-paris23" 
-startDate: "07/17/2023" 
-endDate: "07/17/2023"
+startDate: "07/18/2023" 
+endDate: "07/20/2023"
 tag: "PLN Event"
-dateTBD: true
+dateTBD: false
 preferredContacts:
   - "email|mailto:miwa@protocol.ai"
 eventHosts:


### PR DESCRIPTION
Event: IPFS + Friends Cafe: Paris

Updates made: 
 - Event's description: "Cafes emerged in Europe in the 17th century as a place to foster community and promote the exchange of ideas and philosophy. We’d like to invite you to join us in Paris during EthCC at the IPFS & Friends Cafe!" 
 - Dates: 07/18 to 07/20
 - dateTBD set as false