### PR TITLE
Add new events 2 5 2024

### DIFF
--- a/content/events/ConsensusFilecoinMeetup2024.md
+++ b/content/events/ConsensusFilecoinMeetup2024.md
@@ -1,0 +1,12 @@
+---
+eventName: "Consensus Filecoin Orbit Meetup Event"
+eventDescription: ""
+eventType: "Conference"
+location: "Austin, United States"
+website: "https://fil.org/events/"
+startDate: "05/29/2024"
+endDate: "05/31/2024"
+tag: "PLN Event"
+dateTBD: false
+eventHosts:
+---

--- a/content/events/FILSeoulNwBaseKoreaWeek2024.md
+++ b/content/events/FILSeoulNwBaseKoreaWeek2024.md
@@ -1,0 +1,12 @@
+---
+eventName: "FIL Seoul Network Base alongside Korea Blockchain Week"
+eventDescription: ""
+eventType: "Conference"
+location: "Seoul, South Korea"
+website: "https://fil.org/events/"
+startDate: "09/04/2024"
+endDate: "09/10/2024"
+tag: "PLN Event"
+dateTBD: false
+eventHosts:
+---

--- a/content/events/FilBangkokDevCon2024.md
+++ b/content/events/FilBangkokDevCon2024.md
@@ -1,0 +1,12 @@
+---
+eventName: "FIL Bangkok alongside DevCon"
+eventDescription: ""
+eventType: "Conference"
+location: "Bangkok, Thailand"
+website: "https://fil.org/events/"
+startDate: "11/10/2024"
+endDate: "11/15/2024"
+tag: "PLN Event"
+dateTBD: false
+eventHosts:
+---

--- a/content/events/FilBrusselsEthCC2024.md
+++ b/content/events/FilBrusselsEthCC2024.md
@@ -1,0 +1,12 @@
+---
+eventName: "FIL Brussels alongside EthCC"
+eventDescription: ""
+eventType: "Conference"
+location: "Brussels, Belgium"
+website: "https://fil.org/events/"
+startDate: "07/10/2024"
+endDate: "07/11/2024"
+tag: "PLN Event"
+dateTBD: false
+eventHosts:
+---

--- a/content/events/FilDevSummitEthDenver2024.md
+++ b/content/events/FilDevSummitEthDenver2024.md
@@ -1,0 +1,11 @@
+---
+eventName: "FIL Dev Summit - ETHDenver"
+eventDescription: "FIL Dev Summit is a gathering of developers, builders, and engaged community members who want to contribute to the core protocol and network evolution of Filecoin (think IPFS Thing, but bigger!). This summit is more than just a meetup—it's a place for meaningful and impactful conversations that help push Filecoin forward."
+website: "https://fildev.io/FDS-3"
+eventType: "Conference"
+location: 'Denver, United States'
+startDate: "02/29/2024"
+endDate: "02/29/2024"
+tag: "PLN Event"
+dateTBD: false
+---

--- a/content/events/FilSingaporeToken2049.md
+++ b/content/events/FilSingaporeToken2049.md
@@ -1,0 +1,12 @@
+---
+eventName: "FIL Singapore alongside TOKEN2049"
+eventDescription: ""
+eventType: "Conference"
+location: "Singapore"
+website: "https://fil.org/events/"
+startDate: "09/18/2024"
+endDate: "09/19/2024"
+tag: "PLN Event"
+dateTBD: false
+eventHosts:
+---

--- a/content/events/FundingTheCommonsSF2024.md
+++ b/content/events/FundingTheCommonsSF2024.md
@@ -1,0 +1,10 @@
+---
+eventName: "Funding the Commons SF"
+eventType: "Conference"
+location: "San Francisco, United States"
+website: "https://fundingthecommons.io/san-francisco-bay-area-2024 "
+startDate: "04/13/2024"
+endDate: "04/14/2024"
+tag: "PLN Event"
+dateTBD: false
+---

--- a/content/events/PlMeetupAtETHDenver2024.md
+++ b/content/events/PlMeetupAtETHDenver2024.md
@@ -1,0 +1,11 @@
+---
+eventName: "Protocol Labs Meetup @ ETHDenver"
+eventDescription: "Join the network wide meetup to catch up with familiar faces and meet fellow members!"
+eventType: "Social"
+location: "Denver, United States"
+website: "https://lu.ma/dg1bhavg"
+startDate: "03/02/2024"
+endDate: "03/02/2024"
+tag: "PLN Event"
+dateTBD: false
+---

--- a/content/events/PlMeetupConsensus2024.md
+++ b/content/events/PlMeetupConsensus2024.md
@@ -1,0 +1,11 @@
+---
+eventName: "Protocol Labs Meetup @ Consensus"
+eventDescription: "Join the network wide meetup to catch up with familiar faces and meet fellow members!"
+website: 'https://lu.ma/8jalfeq9'
+eventType: "Social"
+location: "Austin, United States"
+startDate: "05/28/2024"
+endDate: "05/28/2024"
+tag: "PLN Event"
+dateTBD: false
+---

--- a/content/events/Token2049DubaiMeetup2024.md
+++ b/content/events/Token2049DubaiMeetup2024.md
@@ -1,0 +1,10 @@
+---
+eventName: "Token2049 Dubai Filecoin Orbit Meetup Event"
+eventType: "Conference"
+location: "Dubai, United Arab Emirates"
+website: "https://fil.org/events/"
+startDate: "04/16/2024"
+endDate: "04/19/2024"
+tag: "PLN Event"
+dateTBD: false
+---


### PR DESCRIPTION
Adding the following new events - 

1. Protocol Labs Meetup @ ETHDenver
2. Funding the Commons SF
3. Token2049 Dubai Filecoin Orbit Meetup Event
4. Consensus Filecoin Orbit Meetup Event
5. FIL Brussels alongside EthCC
6. FIL Seoul Network Base alongside Korea Blockchain Week
7. FIL Singapore alongside TOKEN2049
8. FIL Bangkok alongside DevCon
9. Protocol Labs Meetup @ Consensus
10. FIL Dev Summit - ETHDenver