### PR TITLE
Update desc ftc 2024 event

### DIFF
--- a/content/events/fundingTheCommons2024.md
+++ b/content/events/fundingTheCommons2024.md
@@ -1,6 +1,6 @@
 ---
 eventName: "Funding the Commons"
-eventDescription: "Consensus is the world's largest, longest-running and most influential gathering that brings together all sides of the cryptocurrency, blockchain and Web3 community."
+eventDescription: "This 2-day event focuses on the rapid innovation underpinning fundamental infrastructure for navigating the digital-physical commons: AI and the Open Web. Join us if you are a builder, researcher, academic, student, funder, philanthropist or public official deeply immersed in (or curious about!) the future of public goods funding."
 eventTopic:
   - AI
   - PGF


### PR DESCRIPTION
Update description for the FTC 2024 event - San Francisco, United States, The David Brower Center